### PR TITLE
Add getwindowid command

### DIFF
--- a/src/help.rs
+++ b/src/help.rs
@@ -41,6 +41,8 @@ Window Query Commands:
         --name
             Match against the window name. This is the same string that is
             displayed in the window titlebar.
+        --id
+            Match windows that belong to a specific id.
         --pid PID
             Match windows that belong to a specific process id. This may not
             work for some X applications that do not set this metadata on its
@@ -94,6 +96,10 @@ Window Action Commands:
     getwindowgeometry [WINDOW]
         Output the geometry (location and position) of a window. The values
         include: x, y, width, height, and (KDE 5 only) screen number.
+
+    getwindowid [WINDOW]
+        Output the ID of a window.
+
 
     getwindowpid [WINDOW]
         Output the PID owning a window. This requires effort from the

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -178,6 +178,7 @@ pub const WINDOW_ACTIONS: phf::Map<&'static str, &'static str> = phf::phf_map! {
     "getwindowname"         => "output_result(w.caption);",
     "getwindowclassname"    => "output_result(w.resourceClass);",
     "getwindowgeometry"     => "output_result(`Window ${w.internalId}`); output_result(`  Position: ${w.x},${w.y}{{#if kde5}} (screen: ${window_screen(w)}){{/if}}`); output_result(`  Geometry: ${w.width}x${w.height}`);",
+    "getwindowid"           => "output_result(w.internalId);",
     "getwindowpid"          => "output_result(w.pid);",
     "windowminimize"        => "w.minimized = true;",
     "windowraise"           => "workspace_raiseWindow(w);",


### PR DESCRIPTION
An example usage for this is the CaptureWindow method in the org.kde.KWin.ScreenShot2 DBus interface which needs the window id. I use this to take a screenshot of the wallpaper (root window) whenever it's updated.