### PR TITLE
Add support for `noBorder` window property .

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## v0.2.2 (2024-09-28)
+
+Added support for `no_border` to `windowstate`
+
 ## v0.2.1 (2023-11-23)
 
 Reduced binary size.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ These commands either take a window-id argument, or use the window stack.
     - fullscreen
     - shaded
     - demands_attention
+    - no_border
   - MISSING:
     - modal
     - sticky

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -224,6 +224,7 @@ pub const WINDOWSTATE_PROPERTIES: phf::Map<&'static str, &'static str> = phf::ph
     "fullscreen" => "fullScreen",
     "shaded" => "shade",
     "demands_attention" => "demandsAttention",
+    "no_border" => "noBorder",
 };
 
 pub const STEP_GLOBAL_ACTION: &str = r#"


### PR DESCRIPTION
Adds support for KWin noBorder property in the windowstate action.
https://develop.kde.org/docs/plasma/kwin/api/#read-only-properties-4