### PR TITLE
added minimized state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release (TBD)
 
 Added support for `no_border` to `windowstate`
+Added support for `minimized` to `windowstate`
 
 ## v0.2.1 (2023-11-23)
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ These commands either take a window-id argument, or use the window stack.
     - shaded
     - demands_attention
     - no_border
+    - minimized
   - MISSING:
     - modal
     - sticky

--- a/src/help.rs
+++ b/src/help.rs
@@ -145,6 +145,7 @@ Window Action Commands:
         SHADED - rolls the window up
         DEMANDS_ATTENTION - marks window urgent or needing attention
         NO_BORDER - window has no border
+	MINIMIZED - set minimized state, can toggle between minimize or maximize.
 
     get_desktop_for_window [WINDOW]
         Output the desktop number that a window is on.

--- a/src/help.rs
+++ b/src/help.rs
@@ -145,7 +145,7 @@ Window Action Commands:
         SHADED - rolls the window up
         DEMANDS_ATTENTION - marks window urgent or needing attention
         NO_BORDER - window has no border
-	MINIMIZED - set minimized state, can toggle between minimize or maximize.
+        MINIMIZED - set minimized state, can toggle between minimize or maximize.
 
     get_desktop_for_window [WINDOW]
         Output the desktop number that a window is on.

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -225,6 +225,7 @@ pub const WINDOWSTATE_PROPERTIES: phf::Map<&'static str, &'static str> = phf::ph
     "shaded" => "shade",
     "demands_attention" => "demandsAttention",
     "no_border" => "noBorder",
+    "minimized" => "minimized",
 };
 
 pub const STEP_GLOBAL_ACTION: &str = r#"


### PR DESCRIPTION
Added minimized state to windowstate, one key difference between this and the existing "windowminimize" is the ability to toggle between minimized and maximized state for a given window:  
kdotool windowstate --toggle minimized <window>

before it was necessary to track the current window state and then decide to either call "windowminimize" or "windowactivate", but this simplifies that by just calling "windowstate --toggle minimized".