### PR TITLE
Remove wtype from suggested alternatives for keyboard commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ These actions aren't targeting a specific window, but the whole desktop.
 
 ## Won't support
 
-You can use `ydotool`, `dotool`, `wtype`, etc. for these:
+You can use `ydotool`, `dotool`, etc. for these:
 
 - Keyboard commands
 - Mouse commands


### PR DESCRIPTION
KWin doesn't support the virtual keyboard protocol that wtype needs, so it is not a good suggestion given that people looking into kdotool are likely using KDE Plasma, so kdotool users won't be able to use wtype anyway.

It doesn't look like the wtype developer is planning to add support for any other methods anyway: https://github.com/atx/wtype/issues/45