### PR TITLE
Fix lost D-Bus results by waiting for script completion

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,15 +9,11 @@ use help::*;
 
 use std::io::Write;
 use std::process::Command;
-use std::sync::RwLock;
-use std::time::Duration;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, anyhow};
-use dbus::{
-    blocking::{Connection, SyncConnection},
-    channel::MatchingReceiver,
-    message::MatchRule,
-};
+use dbus::{blocking::Connection, channel::MatchingReceiver, message::MatchRule};
 use serde::Serialize;
 
 #[derive(Default, Serialize)]
@@ -35,8 +31,6 @@ struct StepResult {
     is_query: bool,
     next_arg: Option<String>,
 }
-
-static MESSAGES: RwLock<Vec<(String, String)>> = RwLock::new(vec![]);
 
 fn add_context<T>(render_context: &mut handlebars::Context, key: &str, value: T)
 where
@@ -166,8 +160,7 @@ fn generate_step(
             if WINDOW_ACTIONS.contains_key(command) {
                 let mut arg_window_id: Option<String> = None;
 
-                let action_script;
-                match command {
+                let action_script = match command {
                     "windowstate" => {
                         let mut opt_windowstate = String::new();
 
@@ -246,10 +239,10 @@ fn generate_step(
 
                         let mut render_context = render_context.clone();
                         add_context(&mut render_context, "windowstate", opt_windowstate);
-                        action_script = reg.render_template_with_context(
+                        reg.render_template_with_context(
                             WINDOW_ACTIONS.get(command).unwrap(),
                             &render_context,
-                        )?;
+                        )?
                     }
 
                     "windowmove" | "windowsize" => {
@@ -327,10 +320,10 @@ fn generate_step(
                         add_context(&mut render_context, "y", y);
                         add_context(&mut render_context, "x_percent", x_percent);
                         add_context(&mut render_context, "y_percent", y_percent);
-                        action_script = reg.render_template_with_context(
+                        reg.render_template_with_context(
                             WINDOW_ACTIONS.get(command).unwrap(),
                             &render_context,
-                        )?;
+                        )?
                     }
 
                     "set_desktop_for_window" => {
@@ -379,10 +372,10 @@ fn generate_step(
                         };
                         let mut render_context = render_context.clone();
                         add_context(&mut render_context, "desktop_id", desktop_id);
-                        action_script = reg.render_template_with_context(
+                        reg.render_template_with_context(
                             WINDOW_ACTIONS.get(command).unwrap(),
                             &render_context,
-                        )?;
+                        )?
                     }
 
                     _ => {
@@ -406,10 +399,10 @@ fn generate_step(
                                 }
                             }
                         }
-                        action_script = reg.render_template_with_context(
+                        reg.render_template_with_context(
                             WINDOW_ACTIONS.get(command).unwrap(),
                             &render_context,
-                        )?;
+                        )?
                     }
                 };
 
@@ -707,7 +700,7 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let self_conn = SyncConnection::new_session()?;
+    let self_conn = Connection::new_session()?;
     context.dbus_addr = self_conn.unique_name().to_string();
 
     log::debug!("===== Generate KWin script =====");
@@ -802,31 +795,51 @@ fn main() -> anyhow::Result<()> {
         Duration::from_millis(5000),
     );
 
-    // setup message receiver
-    let _receiver_thread = std::thread::spawn(move || {
-        let _receiver = self_conn.start_receive(
-            MatchRule::new_method_call(),
-            Box::new(|message, _connection| -> bool {
-                log::debug!("dbus message: {:?}", message);
-                if let Some(member) = message.member()
-                    && let Some(arg) = message.get1()
-                {
-                    let mut messages = MESSAGES.write().unwrap();
-                    messages.push((member.to_string(), arg));
-                }
-                true
-            }),
-        );
-        loop {
-            self_conn.process(Duration::from_millis(1000)).unwrap();
-        }
-        //FIXME: shut down this thread when the script is finished
-    });
+    let (tx, rx) = mpsc::channel();
+    let _receiver = self_conn.start_receive(
+        MatchRule::new_method_call(),
+        Box::new(move |message, connection| -> bool {
+            log::debug!("dbus message: {:?}", message);
+            if let Some(member) = message.member()
+                && let Some(arg) = message.get1::<String>()
+            {
+                let _ = tx.send((member.to_string(), arg));
+                let _ = connection.channel().send(message.method_return());
+            }
+            true
+        }),
+    );
 
     let start_time = chrono::Local::now();
-    let _: () = script_proxy.method_call("org.kde.kwin.Script", "run", ())?;
-    if context.shortcut.is_empty() {
-        let _: () = script_proxy.method_call("org.kde.kwin.Script", "stop", ())?;
+    let mut messages = Vec::new();
+    let result = (|| -> anyhow::Result<()> {
+        let _: () = script_proxy.method_call("org.kde.kwin.Script", "run", ())?;
+        let deadline = Instant::now() + Duration::from_secs(5);
+        // The run() reply is on a different connection from the results. Wait
+        // for a marker on the results connection before stopping the script.
+        loop {
+            for (member, arg) in rx.try_iter() {
+                if member == "finished" && arg == context.marker {
+                    return Ok(());
+                }
+                messages.push((member, arg));
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(anyhow!("Timed out waiting for KWin script completion"));
+            }
+            self_conn.process(remaining)?;
+        }
+    })();
+    // Keep successfully registered shortcuts loaded, but clean up failed runs.
+    if context.shortcut.is_empty() || result.is_err() {
+        let cleanup: Result<(), _> = kwin_proxy.method_call(
+            "org.kde.kwin.Scripting",
+            "unloadScript",
+            (&context.script_name,),
+        );
+        result?;
+        cleanup?;
     }
 
     if context.debug {
@@ -852,7 +865,6 @@ fn main() -> anyhow::Result<()> {
 
     log::debug!("===== Output =====");
     let mut errors = 0;
-    let messages = MESSAGES.read().unwrap();
     for (msgtype, message) in messages.iter() {
         if msgtype == "error" {
             errors += 1;

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -67,12 +67,17 @@ pub const SCRIPT_FOOTER: &str = r#"
 {{#if shortcut}}
 registerShortcut("{{#if script_name}}{{{script_name}}}{{else}}{{{marker}}}{{/if}}", "{{#if script_name}}{{{script_name}}}{{else}}{{{cmdline}}}{{/if}}", "{{{shortcut}}}", run);
 {{else}}
-run();
+try {
+    run();
+} catch (e) {
+    output_error("Script error: " + e.toString());
+}
 {{/if}}
 
 {{#if debug}}
 print("{{{marker}}} FINISH");
 {{/if}}
+callDBus("{{{dbus_addr}}}", "/", "", "finished", "{{{marker}}}");
 "#;
 
 pub const STEP_SEARCH: &str = r#"

--- a/tests/completion.rs
+++ b/tests/completion.rs
@@ -1,0 +1,107 @@
+//! Live regression tests: cargo test --test completion -- --ignored
+//! Requires a running KDE Plasma 6 session. These tests do not activate windows.
+
+#![cfg(feature = "cli")]
+
+use std::process::Command;
+
+#[test]
+#[ignore = "requires a KDE Plasma 6 session"]
+fn receives_every_result_before_exiting() {
+    let expected: String = (0..1000).map(|i| format!("{i}\n")).collect();
+    for _ in 0..100 {
+        let output = Command::new(env!("CARGO_BIN_EXE_kdotool"))
+            .args([
+                "kwinscript",
+                "--inline",
+                "for (let i = 0; i < 1000; ++i) output_result(i);",
+            ])
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{:?}", output);
+        assert_eq!(String::from_utf8(output.stdout).unwrap(), expected);
+    }
+}
+
+#[test]
+#[ignore = "requires a KDE Plasma 6 session"]
+fn completes_without_results_and_reports_errors() {
+    for (script, success) in [
+        ("", true),
+        ("output_error('expected error');", false),
+        ("throw new Error('expected error');", false),
+    ] {
+        let output = Command::new(env!("CARGO_BIN_EXE_kdotool"))
+            .args(["kwinscript", "--inline", script])
+            .output()
+            .unwrap();
+        assert_eq!(output.status.success(), success, "{:?}", output);
+        assert!(output.stdout.is_empty());
+        if !success {
+            assert!(String::from_utf8_lossy(&output.stderr).contains("expected error"));
+        }
+    }
+}
+
+#[test]
+#[ignore = "requires a KDE Plasma 6 session; takes five seconds"]
+fn missing_completion_times_out_and_unloads_script() {
+    let name = format!("kdotool-completion-test-{}", std::process::id());
+    let output = Command::new(env!("CARGO_BIN_EXE_kdotool"))
+        .args([
+            "--name",
+            &name,
+            "kwinscript",
+            "--inline",
+            "callDBus = function () {};",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Timed out"));
+
+    let conn = dbus::blocking::Connection::new_session().unwrap();
+    let proxy = conn.with_proxy(
+        "org.kde.KWin",
+        "/Scripting",
+        std::time::Duration::from_secs(5),
+    );
+    let (loaded,): (bool,) = proxy
+        .method_call("org.kde.kwin.Scripting", "isScriptLoaded", (&name,))
+        .unwrap();
+    assert!(!loaded);
+}
+
+#[test]
+#[ignore = "requires a KDE Plasma 6 session; temporarily registers an unbound shortcut"]
+fn shortcut_registration_completes_without_running_action() {
+    let name = format!("kdotool-shortcut-test-{}", std::process::id());
+    let output = Command::new(env!("CARGO_BIN_EXE_kdotool"))
+        .args([
+            "--name",
+            &name,
+            "--shortcut",
+            "none",
+            "kwinscript",
+            "--inline",
+            "output_error('action must not run during registration');",
+        ])
+        .output()
+        .unwrap();
+    let conn = dbus::blocking::Connection::new_session().unwrap();
+    let proxy = conn.with_proxy(
+        "org.kde.KWin",
+        "/Scripting",
+        std::time::Duration::from_secs(5),
+    );
+    let (loaded,): (bool,) = proxy
+        .method_call("org.kde.kwin.Scripting", "isScriptLoaded", (&name,))
+        .unwrap();
+    let _: (bool,) = proxy
+        .method_call("org.kde.kwin.Scripting", "unloadScript", (&name,))
+        .unwrap();
+    assert!(output.status.success(), "{:?}", output);
+    assert!(loaded);
+    assert!(String::from_utf8_lossy(&output.stdout).contains("Shortcut registered:"));
+    assert!(output.stderr.is_empty(), "{:?}", output);
+}


### PR DESCRIPTION
## Summary
Fixes #46. Related to #49.

The CLI starts an unjoined receiver thread, calls KWin run/stop on a separate D-Bus connection, then immediately prints the messages collected so far. The run/stop replies do not establish that the receiver has processed the result messages. This can produce empty or incomplete output with exit status 0. Registering the receiver earlier addresses startup ordering but does not provide a completion barrier. Extra work under --debug can mask the race by delaying output and exit.

## Changes
- Register the result handler synchronously and process its connection on the main thread, removing the background thread and global result buffer.
- Send a final, per-invocation finished marker from the generated JavaScript, after results or shortcut registration. Wait for that marker before unloading the script and printing results.
- Acknowledge received D-Bus method calls.
- Report a five-second completion timeout instead of silently returning success; unload failed invocations while preserving successfully registered shortcuts.
- Catch synchronous JavaScript runtime exceptions so errors are reported and the completion marker can still be sent.
- Add four opt-in live regression tests covering bulk result delivery, no output/errors, timeout cleanup, and shortcut registration. Gate them on the cli feature so library-only builds continue to work.

Includes a behavior-preserving match-expression initialization refactor to satisfy a pre-existing needless_late_init warning under Clippy 1.98 and the repository hooks.

## Verification
On a live Plasma Wayland session, alternated calls to unmodified and fixed release builds, using the same script:

```sh
kdotool kwinscript --inline 'output_result("ready");'
```

No retries or debug logging were used. The unmodified build was built from upstream commit 084262f.

| Result | Before | After |
| --- | ---: | ---: |
| Runs | 10,000 | 10,000 |
| Correct output | 9,974 | 10,000 |
| Missing output | 26 | 0 |
| Nonzero exit status | 0 | 0 |

Also observed zero failures in 1,000 Firefox searches with the fix. These observations are not a guarantee across all environments; additional testing on affected systems would be welcome.

Passed:
- cargo test --all
- cargo test --no-default-features
- cargo check --all
- cargo clippy --all -- -D warnings
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- KDE_SESSION_VERSION=6 cargo test --release --test completion -- --ignored --test-threads=1 (all four live tests, including 100 runs of 1,000 results each)

The normal test suite skips the live tests because they require KWin. Both commit and push hooks passed without bypasses.

The completion marker covers the synchronous script body or shortcut registration; this does not add support for waiting on arbitrary asynchronous callbacks in custom scripts.