### PR TITLE
Search windows in topmost-first stacking order by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ These commands generate a window stack that following _window action_ commands c
 - `getmouselocation [--shell]`
   - Window stack contains the topmost window under the mouse pointer.
 
+`search --topmost` returns matches in visual stacking order, topmost first.
+Combine it with `--limit 1` to select the topmost matching window:
+
+```sh
+kdotool search --class code --topmost --limit 1 windowactivate
+```
+
 ### Window Actions
 
 These commands either take a window-id argument, or use the window stack.

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ These commands generate a window stack that following _window action_ commands c
 - `getmouselocation [--shell]`
   - Window stack contains the topmost window under the mouse pointer.
 
-`search --topmost` returns matches in visual stacking order, topmost first.
+`search` returns matches in visual stacking order, topmost first.
 Combine it with `--limit 1` to select the topmost matching window:
 
 ```sh
-kdotool search --class code --topmost --limit 1 windowactivate
+kdotool search --class code --limit 1 windowactivate
 ```
 
 ### Window Actions

--- a/completions/kdotool.bash
+++ b/completions/kdotool.bash
@@ -41,7 +41,6 @@ _kdotool() {
           -p --pid
           -D --desktop
           -l --limit
-          --topmost
           -a --all --any
         ' -- "$cur"))
         ;;

--- a/completions/kdotool.bash
+++ b/completions/kdotool.bash
@@ -41,6 +41,7 @@ _kdotool() {
           -p --pid
           -D --desktop
           -l --limit
+          --topmost
           -a --all --any
         ' -- "$cur"))
         ;;
@@ -71,4 +72,3 @@ _kdotool() {
 }
 
 complete -F _kdotool kdotool
-

--- a/src/help.rs
+++ b/src/help.rs
@@ -27,7 +27,7 @@ Options:
 Window Query Commands:
     search [OPTIONS] PATTERN    
         Search for windows with titles, names, or classes matching a regular
-        expression pattern.
+        expression pattern. Results are in stacking order, topmost first.
 
         The default options are --title --class --classname --role (unless you
         specify one or more of --title, --class, --classname, or --role).
@@ -54,9 +54,6 @@ Window Query Commands:
         -l, --limit NUMBER
             Stop searching after finding NUMBER matching windows. The default
             is no search limit (which is equivalent to '--limit 0')
-        --topmost
-            Search in stacking order, topmost first, before applying --limit.
-            This is visual stacking order, not focus history.
         -a, --all
             Require that all conditions be met.
         --any

--- a/src/help.rs
+++ b/src/help.rs
@@ -54,6 +54,9 @@ Window Query Commands:
         -l, --limit NUMBER
             Stop searching after finding NUMBER matching windows. The default
             is no search limit (which is equivalent to '--limit 0')
+        --topmost
+            Search in stacking order, topmost first, before applying --limit.
+            This is visual stacking order, not focus history.
         -a, --all
             Require that all conditions be met.
         --any

--- a/src/main.rs
+++ b/src/main.rs
@@ -527,7 +527,6 @@ fn step_search(
         match_desktop: bool,
         desktop: i32,
         limit: u32,
-        topmost: bool,
         match_all: bool,
         match_case: bool,
         search_term: String,
@@ -570,9 +569,6 @@ fn step_search(
             }
             Short('l') | Long("limit") => {
                 opt.limit = parser.value()?.parse()?;
-            }
-            Long("topmost") => {
-                opt.topmost = true;
             }
             Short('a') | Long("all") => {
                 opt.match_all = true;
@@ -900,48 +896,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn search_preserves_default_order() {
+    fn search_uses_topmost_order_before_limit_and_supports_chaining() {
         let script = generate_script(
             &Globals::default(),
-            Parser::from_args(["--class", "code", "--limit", "1"]),
+            Parser::from_args(["--class", "code", "--limit", "1", "windowactivate"]),
             "search",
         )
         .unwrap();
-        assert!(script.contains("var t = workspace_windowList();"));
+        let order = script
+            .find("var t = workspace.stackingOrder.slice().reverse();")
+            .unwrap();
+        let search = script.find("for (var i=0; i<t.length; i++)").unwrap();
+        let limit = script
+            .find("if (1 > 0 && window_stack.length >= 1)")
+            .unwrap();
+        assert!(order < search && search < limit);
         assert!(!script.contains("t.sort("));
-    }
-
-    #[test]
-    fn topmost_sorts_before_searching_and_supports_chaining() {
-        for args in [
-            [
-                "--topmost",
-                "--class",
-                "code",
-                "--limit",
-                "1",
-                "windowactivate",
-            ],
-            [
-                "--class",
-                "code",
-                "--limit",
-                "1",
-                "--topmost",
-                "windowactivate",
-            ],
-        ] {
-            let script =
-                generate_script(&Globals::default(), Parser::from_args(args), "search").unwrap();
-            let sort = script
-                .find("t.sort((a, b) => b.stackingOrder - a.stackingOrder);")
-                .unwrap();
-            let search = script.find("for (var i=0; i<t.length; i++)").unwrap();
-            let limit = script
-                .find("if (1 > 0 && window_stack.length >= 1)")
-                .unwrap();
-            assert!(sort < search && search < limit);
-            assert!(script.contains("workspace_setActiveWindow(w);"));
-        }
+        assert!(script.contains("workspace_setActiveWindow(w);"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -527,6 +527,7 @@ fn step_search(
         match_desktop: bool,
         desktop: i32,
         limit: u32,
+        topmost: bool,
         match_all: bool,
         match_case: bool,
         search_term: String,
@@ -569,6 +570,9 @@ fn step_search(
             }
             Short('l') | Long("limit") => {
                 opt.limit = parser.value()?.parse()?;
+            }
+            Long("topmost") => {
+                opt.topmost = true;
             }
             Short('a') | Long("all") => {
                 opt.match_all = true;
@@ -888,5 +892,56 @@ fn main() -> anyhow::Result<()> {
         Err(anyhow!("Script finished with {errors} error(s)"))
     } else {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_preserves_default_order() {
+        let script = generate_script(
+            &Globals::default(),
+            Parser::from_args(["--class", "code", "--limit", "1"]),
+            "search",
+        )
+        .unwrap();
+        assert!(script.contains("var t = workspace_windowList();"));
+        assert!(!script.contains("t.sort("));
+    }
+
+    #[test]
+    fn topmost_sorts_before_searching_and_supports_chaining() {
+        for args in [
+            [
+                "--topmost",
+                "--class",
+                "code",
+                "--limit",
+                "1",
+                "windowactivate",
+            ],
+            [
+                "--class",
+                "code",
+                "--limit",
+                "1",
+                "--topmost",
+                "windowactivate",
+            ],
+        ] {
+            let script =
+                generate_script(&Globals::default(), Parser::from_args(args), "search").unwrap();
+            let sort = script
+                .find("t.sort((a, b) => b.stackingOrder - a.stackingOrder);")
+                .unwrap();
+            let search = script.find("for (var i=0; i<t.length; i++)").unwrap();
+            let limit = script
+                .find("if (1 > 0 && window_stack.length >= 1)")
+                .unwrap();
+            assert!(sort < search && search < limit);
+            assert!(script.contains("workspace_setActiveWindow(w);"));
+        }
     }
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -86,6 +86,9 @@ pub const STEP_SEARCH: &str = r#"
     const re_opts = (match_case ? "" : "i");
     const re = new RegExp(String.raw`{{{search_term}}}`, re_opts);
     var t = workspace_windowList();
+    {{#if topmost}}
+    t.sort((a, b) => b.stackingOrder - a.stackingOrder);
+    {{/if}}
     window_stack = [];
     for (var i=0; i<t.length; i++) {
         let w = t[i];

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -85,10 +85,8 @@ pub const STEP_SEARCH: &str = r#"
     const match_case = {{{match_case}}};
     const re_opts = (match_case ? "" : "i");
     const re = new RegExp(String.raw`{{{search_term}}}`, re_opts);
-    var t = workspace_windowList();
-    {{#if topmost}}
-    t.sort((a, b) => b.stackingOrder - a.stackingOrder);
-    {{/if}}
+    // KWin exposes a read-only, bottom-to-top sequence. Copy before reversing.
+    var t = workspace.stackingOrder.slice().reverse();
     window_stack = [];
     for (var i=0; i<t.length; i++) {
         let w = t[i];

--- a/tests/topmost.rs
+++ b/tests/topmost.rs
@@ -1,0 +1,62 @@
+#![cfg(feature = "cli")]
+
+use std::process::Command;
+
+#[test]
+#[ignore = "requires a KDE Plasma 6 session; does not activate windows"]
+fn topmost_matches_stacking_order_before_applying_limit() {
+    // Use KWin's ordered list as an independent reference for the per-window
+    // stackingOrder sort. Restrict it to the same candidates as normal search.
+    let output = Command::new(env!("CARGO_BIN_EXE_kdotool"))
+        .args([
+            "kwinscript",
+            "--inline",
+            "const candidates = workspace.windowList();
+             output_result(JSON.stringify(workspace.stackingOrder
+                 .filter(w => candidates.includes(w)).reverse()
+                 .map(w => w.internalId.toString())));",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    let expected: Vec<String> = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(!expected.is_empty(), "test requires open windows");
+
+    for limit in [0, 1, 2] {
+        let output = Command::new(env!("CARGO_BIN_EXE_kdotool"))
+            .args([
+                "search",
+                "--class",
+                "^.*$",
+                "--topmost",
+                "--limit",
+                &limit.to_string(),
+            ])
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{output:?}");
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        let actual: Vec<_> = stdout.lines().collect();
+        let count = if limit == 0 {
+            expected.len()
+        } else {
+            limit.min(expected.len())
+        };
+        assert_eq!(actual, expected[..count]);
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kdotool"))
+        .args([
+            "search",
+            "--class",
+            "a^",
+            "--topmost",
+            "--limit",
+            "1",
+            "windowactivate",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    assert!(output.stdout.is_empty());
+}

--- a/tests/topmost.rs
+++ b/tests/topmost.rs
@@ -5,16 +5,18 @@ use std::process::Command;
 #[test]
 #[ignore = "requires a KDE Plasma 6 session; does not activate windows"]
 fn topmost_matches_stacking_order_before_applying_limit() {
-    // Use KWin's ordered list as an independent reference for the per-window
-    // stackingOrder sort. Restrict it to the same candidates as normal search.
+    // Walk KWin's stack backwards as a reference, without mutating the
+    // read-only Qt sequence or using the search implementation's reverse().
     let output = Command::new(env!("CARGO_BIN_EXE_kdotool"))
         .args([
             "kwinscript",
             "--inline",
-            "const candidates = workspace.windowList();
-             output_result(JSON.stringify(workspace.stackingOrder
-                 .filter(w => candidates.includes(w)).reverse()
-                 .map(w => w.internalId.toString())));",
+            "const stack = workspace.stackingOrder;
+             const ids = [];
+             for (let i = stack.length - 1; i >= 0; --i) {
+                 ids.push(stack[i].internalId.toString());
+             }
+             output_result(JSON.stringify(ids));",
         ])
         .output()
         .unwrap();
@@ -24,14 +26,7 @@ fn topmost_matches_stacking_order_before_applying_limit() {
 
     for limit in [0, 1, 2] {
         let output = Command::new(env!("CARGO_BIN_EXE_kdotool"))
-            .args([
-                "search",
-                "--class",
-                "^.*$",
-                "--topmost",
-                "--limit",
-                &limit.to_string(),
-            ])
+            .args(["search", "--class", "^.*$", "--limit", &limit.to_string()])
             .output()
             .unwrap();
         assert!(output.status.success(), "{output:?}");
@@ -46,15 +41,7 @@ fn topmost_matches_stacking_order_before_applying_limit() {
     }
 
     let output = Command::new(env!("CARGO_BIN_EXE_kdotool"))
-        .args([
-            "search",
-            "--class",
-            "a^",
-            "--topmost",
-            "--limit",
-            "1",
-            "windowactivate",
-        ])
+        .args(["search", "--class", "a^", "--limit", "1", "windowactivate"])
         .output()
         .unwrap();
     assert!(output.status.success(), "{output:?}");


### PR DESCRIPTION
## Summary
Make `search` return matches in visual stacking order, topmost first, using KWin’s existing `workspace.stackingOrder` list.

This allows selecting the topmost matching application window directly:

```sh
kdotool search --class code --limit 1 windowactivate
```

Revised following @jinliu’s feedback: the proposed `--topmost` flag and explicit `sort()` have been removed; stacking order is now the default.

## Implementation
- Read search candidates using `workspace.stackingOrder.slice().reverse()` before matching and applying `--limit`.
- Copy before reversing because KWin exposes a read-only Qt sequence. Direct `workspace.stackingOrder.reverse()` was tested on a live session and fails with `TypeError: Cannot insert into a readonly container`; `slice().reverse()` works and leaves KWin’s original order intact.
- Update help and README examples to describe the default ordering.
- Update the unit test for ordering before limits and command chaining.
- Update the opt-in live test to compare search results against a backward traversal of KWin’s stack, for limits 0, 1, and 2, and verify an empty search followed by a window action.

## Verification
Passed:
- `cargo test --all`
- `cargo test --no-default-features`
- `cargo check --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `KDE_SESSION_VERSION=6 cargo test --release -- --ignored --test-threads=1` (all five live tests, including the existing D-Bus completion regressions)

The revised local launcher successfully focuses the matching Code window and runs the supplied command when no window matches. Both commit and push hooks passed.